### PR TITLE
Quadprog dependency upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.18.1
 scipy>=1.3.3
-quadprog==0.1.7
+quadprog~=0.1.11
 matplotlib>=3.3.1

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     install_requires=[
         'numpy>=1.18.1',
         'scipy>=1.3.3',
-        'quadprog==0.1.7',
+        'quadprog~=0.1.11',
         'matplotlib>=3.3.1'
     ],
     classifiers=[
@@ -30,6 +30,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
         "Operating System :: OS Independent",
     ])


### PR DESCRIPTION
Installation on Windows 10 and Ubuntu 22.04 currently fails because of compilation errors with the quadprog dependency.

```shell 
quadprog.obj : error LNK2001: unresolved external symbol "void __cdecl qpgen2_(double *,double *,int *,int *,double *,double *,double *,double *,double *,int *,int *,int *,int *,int *
,int *,double *,int *)" (?qpgen2_@@YAXPEAN0PEAH10000011111101@Z)
        Hint on symbols that are defined and could potentially match:
          qpgen2_
      build\lib.win-amd64-3.8\quadprog.cp38-win_amd64.pyd : fatal error LNK1120: 1 unresolved externals
      error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\BuildTools\\VC\\Tools\\MSVC\\14.29.30133\\bin\\HostX86\\x64\\link.exe' failed with exit status 1120
      [end of output]
```
Bumping this up to >0.1.7 works, so I have changed the dependency to ~=0.1.11 to allow for flexibility.

I have tested the changes on Windows 10 and [Ubuntu 22.04](https://github.com/PascalReich/trajectory_planning_helpers/actions/runs/7241661372) with the new python versions by using the tests you wrote for when you directly call each file. 

This repository also works for Python 3.9 and 3.10, so I have added those to the setup.py. Notably, Python 3.11 does not work. Quadprog and its dependency Cython are having issues with Python 3.11, so perhaps in the future support can be added.